### PR TITLE
update openjdk-8-jre-headless and ca-certificates-java to versions that are actually present in Debian Jessie repos

### DIFF
--- a/willow/Dockerfile
+++ b/willow/Dockerfile
@@ -44,12 +44,12 @@ RUN { \
 
 ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64/jre
 
-ENV JAVA_VERSION 8u111
-ENV JAVA_DEBIAN_VERSION 8u111-b14-2~bpo8+1
+ENV JAVA_VERSION 8u121
+ENV JAVA_DEBIAN_VERSION 8u121-b13-1~bpo8+1
 
 # see https://bugs.debian.org/775775
 # and https://github.com/docker-library/java/issues/19#issuecomment-70546872
-ENV CA_CERTIFICATES_JAVA_VERSION 20140324
+ENV CA_CERTIFICATES_JAVA_VERSION 20161107~bpo8+1
 
 RUN set -x \
 	&& apt-get update \


### PR DESCRIPTION
We can close #82 if somebody else could verify with `docker-compose down && docker-compose build --no-cache && docker-compose up` that it really is fixed.