### PR TITLE
add git submodule registration / checkout and update to deploy script

### DIFF
--- a/deploy/deploy_demo.sh
+++ b/deploy/deploy_demo.sh
@@ -2,5 +2,6 @@
 cd /home/willow/willow
 git checkout master
 git pull --recurse-submodules
+git submodule update --recursive --init
 ln -sf ../envfile .env
 docker-compose down --remove-orphans && docker-compose build && docker-compose up -d


### PR DESCRIPTION
#89 required the willow repo to be deleted on the demo server. I did that, made sure .env was available, and re-ran the lastest `master` build. It failed with

```
Step 4/10 : ADD geoblacklight/solr/config $SOLR_HOME/geoblacklight_config
Service 'solr' failed to build: lstat geoblacklight/solr/config: no such file or directory
```
I checked, and the git submodule geoblacklight was not "registered" and not checked out. It works if I run `git submodule init && git submodule update` manually, but of course we want the deploy script to always work.