### PR TITLE
add support for optionally specifying Postgres DB via ENV

### DIFF
--- a/fedora_commons/setenv.sh
+++ b/fedora_commons/setenv.sh
@@ -11,7 +11,7 @@ export CATALINA_OPTS="$CATALINA_OPTS -XX:+UseG1GC"
 export CATALINA_OPTS="$CATALINA_OPTS -XX:+DisableExplicitGC"
 
 export CATALINA_OPTS="$CATALINA_OPTS -Dfcrepo.modeshape.configuration=classpath:/config/jdbc-postgresql/repository.json"
-export CATALINA_OPTS="$CATALINA_OPTS -Dfcrepo.postgresql.host=db"
+export CATALINA_OPTS="$CATALINA_OPTS -Dfcrepo.postgresql.host=${POSTGRES_HOST:-db}"
 export CATALINA_OPTS="$CATALINA_OPTS -Dfcrepo.postgresql.port=5432"
 export CATALINA_OPTS="$CATALINA_OPTS -Dfcrepo.postgresql.username=${POSTGRES_USER}"
 export CATALINA_OPTS="$CATALINA_OPTS -Dfcrepo.postgresql.password=${POSTGRES_PASSWORD}"

--- a/willow/config/database.yml
+++ b/willow/config/database.yml
@@ -3,7 +3,7 @@ default: &default
   pool: 5
   timeout: 5000
   encoding: unicode
-  host: db
+  host: <%= ENV['POSTGRES_HOST'] || 'db' %>
   username: <%= ENV['POSTGRES_USER'] %>
   password: <%= ENV['POSTGRES_PASSWORD'] %>
 


### PR DESCRIPTION
This does not change anybody's local env and does not require that POSTGRES_HOST be set. But it can be set, which is what I want to do on AWS in production.