### PR TITLE
externalise Fedora, Solr and Redis config in ENV vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,9 @@ __example .env file__
 ```bash
 # POSTGRES_HOST=hostname, defaults to "db" used by docker-compose
 # POSTGRES_PORT=5432 by default
+# FEDORA_URL_SCHEME, FEDORA_HOST and FEDORA_PORT can be set but are not required for a development env
+# SOLR_URL_SCHEME, SOLR_HOST and SOLR_PORT can be set but are not required for a development env
+# REDIS_HOST and REDIS_PORT can be set but are not required for a development env
 POSTGRES_USER=postgres
 POSTGRES_PASSWORD=password
 

--- a/README.md
+++ b/README.md
@@ -42,9 +42,9 @@ __example .env file__
 ```bash
 # POSTGRES_HOST=hostname, defaults to "db" used by docker-compose
 # POSTGRES_PORT=5432 by default
-# FEDORA_URL_SCHEME, FEDORA_HOST and FEDORA_PORT can be set but are not required for a development env
-# SOLR_URL_SCHEME, SOLR_HOST and SOLR_PORT can be set but are not required for a development env
-# REDIS_HOST and REDIS_PORT can be set but are not required for a development env
+# FEDORA_URL_SCHEME, FEDORA_HOST and FEDORA_PORT can be set. Default values are provided if not set.
+# SOLR_URL_SCHEME, SOLR_HOST and SOLR_PORT can be set. Default values are provided if not set.
+# REDIS_HOST and REDIS_PORT can be set. Default values are provided if not set.
 POSTGRES_USER=postgres
 POSTGRES_PASSWORD=password
 

--- a/willow/config/fedora.yml
+++ b/willow/config/fedora.yml
@@ -1,15 +1,15 @@
 development:
   user: fedoraAdmin
   password: fedoraAdmin
-  url: http://fedora:8080/rest
+  url: <%= ENV['FEDORA_URL_SCHEME'] || 'http' %>://<%= ENV['FEDORA_HOST'] || 'fedora' %>:<%= ENV['FEDORA_PORT'] || '8080' %>/rest
   base_path: /willow_development
 test:
   user: fedoraAdmin
   password: fedoraAdmin
-  url: http://fedora:8080/rest
+  url: <%= ENV['FEDORA_URL_SCHEME'] || 'http' %>://<%= ENV['FEDORA_HOST'] || 'fedora' %>:<%= ENV['FEDORA_PORT'] || '8080' %>/rest
   base_path: /willow_test
 production:
   user: fedoraAdmin
   password: fedoraAdmin
-  url: http://fedora:8080/rest
+  url: <%= ENV['FEDORA_URL_SCHEME'] || 'http' %>://<%= ENV['FEDORA_HOST'] || 'fedora' %>:<%= ENV['FEDORA_PORT'] || '8080' %>/rest
   base_path: /willow_production

--- a/willow/config/redis.yml
+++ b/willow/config/redis.yml
@@ -1,9 +1,9 @@
 development:
-  host: redis
-  port: 6379
+  host: <%= ENV['REDIS_HOST'] || 'redis' %>
+  port: <%= ENV['REDIS_PORT'] || '6379' %>
 test:
-  host: redis
-  port: 6379
+  host: <%= ENV['REDIS_HOST'] || 'redis' %>
+  port: <%= ENV['REDIS_PORT'] || '6379' %>
 production:
-  host: redis
-  port: 6379
+  host: <%= ENV['REDIS_HOST'] || 'redis' %>
+  port: <%= ENV['REDIS_PORT'] || '6379' %>

--- a/willow/config/solr.yml
+++ b/willow/config/solr.yml
@@ -1,7 +1,7 @@
 # This is a sample config file that points to a solr server for each environment
 development:
-  url: http://solr:8983/solr/willow_development
+  url: <%= ENV['SOLR_URL_SCHEME'] || 'http' %>://<%= ENV['SOLR_HOST'] || 'solr' %>:<%= ENV['SOLR_PORT'] || '8983' %>/solr/willow_development
 test:
-  url: http://solr:8983/solr/willow_test
+  url: <%= ENV['SOLR_URL_SCHEME'] || 'http' %>://<%= ENV['SOLR_HOST'] || 'solr' %>:<%= ENV['SOLR_PORT'] || '8983' %>/solr/willow_test
 production:
-  url: http://solr:8983/solr/willow_production
+  url: <%= ENV['SOLR_URL_SCHEME'] || 'http' %>://<%= ENV['SOLR_HOST'] || 'solr' %>:<%= ENV['SOLR_PORT'] || '8983' %>/solr/willow_production


### PR DESCRIPTION
For #182 

Tested locally (incl geoblacklight). Willow tested by creating a work and observing it go into Fedora and Solr. Not sure how to test Redis, but I assume that's necessary for the work to go into the other 2.