### PR TITLE
Fix docker host dependencies

### DIFF
--- a/fedora_commons/Dockerfile
+++ b/fedora_commons/Dockerfile
@@ -24,7 +24,7 @@ FROM tomcat:9
 # "
 
 # For Willow purposes:
-# CATALINA_HOME is set by the Tomcar Docker image. There should be no need to change it.
+# CATALINA_HOME is set by the Tomcat Docker image. There should be no need to change it.
 # CATALINA_BASE is the directory where settings specific to the Fedora Commons app need to be held.
 
 # As per the description above, certain directories in CATALINA_BASE are static assets (bin, conf, lib)

--- a/fedora_commons/Dockerfile
+++ b/fedora_commons/Dockerfile
@@ -1,22 +1,68 @@
 FROM tomcat:9
 
-ENV FCREPO4_HOME=/fcrepo4_home \
+# There are different ENV vars to consider when running Fedora Commons.
+# An explanation of running Tomcat from https://stackoverflow.com/a/29398713/1154882
+
+# "
+# In many circumstances, it is desirable to have a single copy of a Tomcat binary distribution shared among multiple users on the same server. To make this possible, you can set the CATALINA_BASE environment variable to the directory that contains the files for your 'personal' Tomcat instance.
+
+# When running with a separate CATALINA_HOME and CATALINA_BASE, the files and directories are split as following:
+
+# In CATALINA_BASE:
+#   bin - Only: setenv.sh (*nix) or setenv.bat (Windows), tomcat-juli.jar
+#   conf - Server configuration files (including server.xml)
+#   lib - Libraries and classes, as explained below
+#   logs - Log and output files
+#   webapps - Automatically loaded web applications
+#   work - Temporary working directories for web applications
+#   temp - Directory used by the JVM for temporary files>
+
+# In CATALINA_HOME:
+#   bin - Startup and shutdown scripts
+#   lib - Libraries and classes, as explained below
+#   endorsed - Libraries that override standard "Endorsed Standards". By default it's absent.
+# "
+
+# For Willow purposes:
+# CATALINA_HOME is set by the Tomcar Docker image. There should be no need to change it.
+# CATALINA_BASE is the directory where settings specific to the Fedora Commons app need to be held.
+
+# As per the description above, certain directories in CATALINA_BASE are static assets (bin, conf, lib)
+# while certain directories change during runtime (logs, webapps, work, temp).
+# The static directories should be baked into the image. The writeable directories should be mounted as volumes.
+# In this case this would result in 3 extra volumes, none of which are particularly useful.
+
+# For Willow, it is easier to make the entire CATALINA_BASE a volume. That means that when the volume is mounted at container
+# start-up, everything done inside CATALINA_BASE in this Dockerfile is going to disappear (unless it's being run on a
+# local developer workstation). All actions that need to be taken inside CATALINA_BASE should be taken in the docker-entrypoint.sh,
+# not here.
+# What we do here is to add all static assets to a static directory, WILLOW_FEDORA_STATIC_DIR. Those will be symlinked
+# into CATALINA_BASE by docker-entrypoint.sh on each container start-up.
+
+# The final result after the container starts is something like this:
+# ls -l $CATALINA_BASE
+#   bin -> $WILLOW_FEDORA_STATIC_DIR/bin
+#   conf -> $WILLOW_FEDORA_STATIC_DIR/conf
+#   lib -> $WILLOW_FEDORA_STATIC_DIR/lib
+#   logs
+#   webapps
+#     ROOT.war -> $WILLOW_FEDORA_STATIC_DIR/webapps/ROOT.war
+#   work
+#   temp
+
+
+ENV WILLOW_FEDORA_STATIC_DIR=/willow_fedora_static \
+    FCREPO4_HOME=/fcrepo4_home \
     FCREPO4_DATA=/fcrepo4_data \
     CATALINA_BASE=/fcrepo4_home
 
-RUN mkdir -p $FCREPO4_HOME/bin \
-    $FCREPO4_HOME/conf \
-    $FCREPO4_HOME/lib \
-    $FCREPO4_HOME/logs \
-    $FCREPO4_HOME/webapps \
-    $FCREPO_HOME/work \
-    $FCREPO4_HOME/temp \
-    /tmp \
-    # Tip: downloading large files with "curl -L <URL> -o <file>" (rather than with DOCKER ADD) allows for the files to be fully cached
-    && curl -L https://github.com/fcrepo4/fcrepo4/releases/download/fcrepo-4.7.2/fcrepo-webapp-4.7.2.war -o $FCREPO4_HOME/webapps/ROOT.war
+RUN mkdir -p $WILLOW_FEDORA_STATIC_DIR $WILLOW_FEDORA_STATIC_DIR/bin $WILLOW_FEDORA_STATIC_DIR/webapps /tmp
 
-COPY conf $FCREPO4_HOME/conf
-COPY setenv.sh $CATALINA_HOME/bin/setenv.sh
+# Tip: downloading large files with "curl -L <URL> -o <file>" (rather than with DOCKER ADD) allows for the files to be fully cached
+RUN curl -L https://github.com/fcrepo4/fcrepo4/releases/download/fcrepo-4.7.2/fcrepo-webapp-4.7.2.war -o $WILLOW_FEDORA_STATIC_DIR/webapps/ROOT.war
+
+COPY conf $WILLOW_FEDORA_STATIC_DIR/conf
+COPY setenv.sh $WILLOW_FEDORA_STATIC_DIR/bin/setenv.sh
 COPY docker-healthcheck.sh /usr/local/bin/
 COPY wait-for-it.sh /usr/local/bin/
 COPY docker-entrypoint.sh /

--- a/fedora_commons/docker-entrypoint.sh
+++ b/fedora_commons/docker-entrypoint.sh
@@ -1,10 +1,20 @@
 #!/bin/bash
 
+# See the associated Fedora Commons Dockerfile for an explanation of important environment variables.
+
 set -e
 
 if [[ "$VERBOSE" = "yes" ]]; then
     set -x
 fi
+
+ln -sf $WILLOW_FEDORA_STATIC_DIR/bin $FCREPO4_HOME/
+ln -sf $WILLOW_FEDORA_STATIC_DIR/conf $FCREPO4_HOME/
+ln -sf $WILLOW_FEDORA_STATIC_DIR/lib $FCREPO4_HOME/
+
+mkdir $FCREPO4_HOME/logs $FCREPO4_HOME/webapps $FCREPO4_HOME/work $FCREPO4_HOME/temp
+
+ln -sf $WILLOW_FEDORA_STATIC_DIR/webapps/ROOT.war $FCREPO4_HOME/webapps/ROOT.war
 
 # TODO: create seed test data rather than reindexing pre-cooked data
 #fedora_created=$FCREPO4_HOME/fedora_created

--- a/fedora_commons/setenv.sh
+++ b/fedora_commons/setenv.sh
@@ -1,4 +1,5 @@
 #! /bin/sh
+# See the associated Fedora Commons Dockerfile for an explanation of important environment variables.
 
 # Options as recommended at https://wiki.duraspace.org/display/FEDORA4X/Java+HotSpot+VM+Options+recommendations
 export CATALINA_OPTS="$CATALINA_OPTS -Djava.awt.headless=true"

--- a/solr/Dockerfile
+++ b/solr/Dockerfile
@@ -1,16 +1,16 @@
 FROM solr:6.4
 
-ENV SOLR_HOME=/solr_home
-
-ADD config/willow $SOLR_HOME/willow_config
-ADD config/geoblacklight $SOLR_HOME/geoblacklight_config
-COPY docker-entrypoint.sh /
+ENV SOLR_CONFIG_DIR=/solr_conf \
+    SOLR_HOME=/solr_home
 
 USER root
-RUN chown -R solr:solr $SOLR_HOME
-
+RUN mkdir $SOLR_HOME $SOLR_CONFIG_DIR
+RUN chown -R solr:solr $SOLR_HOME $SOLR_CONFIG_DIR
 
 USER solr
-RUN cp /opt/solr/server/solr/solr.xml $SOLR_HOME
+ADD config/willow $SOLR_CONFIG_DIR/willow_config
+ADD config/geoblacklight $SOLR_CONFIG_DIR/geoblacklight_config
+COPY docker-entrypoint.sh /
+
 ENTRYPOINT ["/docker-entrypoint.sh"]
 

--- a/solr/docker-entrypoint.sh
+++ b/solr/docker-entrypoint.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 #
 # Creates the solr cores required for Willow and friends
+# SOLR_HOME = data folder, usually mounted as a volume
+# SOLR_CONFIG_DIR = a directory of static solr configuration files baked into the Docker image at build time.
 
 set -e
 
@@ -8,9 +10,11 @@ if [[ "$VERBOSE" = "yes" ]]; then
     set -x
 fi
 
+cp /opt/solr/server/solr/solr.xml $SOLR_HOME/
 
 . /opt/docker-solr/scripts/run-initdb
 
+SOLR_CONFIG_DIR=/solr_conf
 
 willow_created=$SOLR_HOME/willow_created
 geoblacklight_created=$SOLR_HOME/geoblacklight_created
@@ -22,17 +26,17 @@ else
 
     if [ ! -f $willow_created ]; then
         echo "Creating willow core(s)"
-        /opt/solr/bin/solr create -c "willow_development" -d "$SOLR_HOME/willow_config"
-        /opt/solr/bin/solr create -c "willow_test" -d "$SOLR_HOME/willow_config"
-        /opt/solr/bin/solr create -c "willow_production" -d "$SOLR_HOME/willow_config"
+        /opt/solr/bin/solr create -c "willow_development" -d "$SOLR_CONFIG_DIR/willow_config"
+        /opt/solr/bin/solr create -c "willow_test" -d "$SOLR_CONFIG_DIR/willow_config"
+        /opt/solr/bin/solr create -c "willow_production" -d "$SOLR_CONFIG_DIR/willow_config"
         touch $willow_created
     fi
 
     if [ ! -f $geoblacklight_created ]; then
       echo "Creating geoblacklight core(s)"
-      /opt/solr/bin/solr create -c "geoblacklight_development" -d "$SOLR_HOME/geoblacklight_config"
-      /opt/solr/bin/solr create -c "geoblacklight_test" -d "$SOLR_HOME/geoblacklight_config"
-      /opt/solr/bin/solr create -c "geoblacklight_production" -d "$SOLR_HOME/geoblacklight_config"
+      /opt/solr/bin/solr create -c "geoblacklight_development" -d "$SOLR_CONFIG_DIR/geoblacklight_config"
+      /opt/solr/bin/solr create -c "geoblacklight_test" -d "$SOLR_CONFIG_DIR/geoblacklight_config"
+      /opt/solr/bin/solr create -c "geoblacklight_production" -d "$SOLR_CONFIG_DIR/geoblacklight_config"
       touch $geoblacklight_created
     fi
 


### PR DESCRIPTION
Currently Willow relies on the github repo being checked out on the system running the Willow docker containers.

That is, static assets which should be baked into the images, are instead relied on being present through docker volumes. But of course, on a production system running somewhere in some cloud, those volumes start off totally empty.

This PR addresses the problem by putting all assets required to run Willow (Solr and Fedora specifically) into the Docker images themselves. It retains volumes for data that changes during runtime, such as user submissions, logs, temporary spaces.

No changes to a developer's local environment are introduced by this PR. You might find that you need to rebuild a bit more often, specifically if you change core Solr or Fedora config. However, the builds are very fast nowadays on our optimised Dockerfiles.

I've tested this by running it with `docker-compose down --volumes && docker-compose up --build` and:

1. observing that start-up seems correct and all containers start
1. there is no unusual logging output
1. seed data is processed as usual
1. making my own submission and finding the related records in Solr and Fedora