### PR TITLE
Feature/225 contact form extra options

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ SMTP_PASSWORD=pass
 # SMTP_HELO_DOMAIN=cottagelabs.com
 
 CONTACT_FORM_RECIPIENT_EMAIL=repo-admin@your-institution.ac.uk
+CONTACT_FORM_SENDER_EMAIL=repo-admin@your-institution.ac.uk
 CONTACT_FORM_SUBJECT_PREFIX="Willow Contact form:"
 NOTIFICATIONS_EMAIL_DEFAULT_FROM_ADDRESS=notifications@your-institution.ac.uk
 # USER_MANAGEMENT_EMAIL_FROM_ADDRESS is used for things like Forgotten Password.

--- a/example.env.production
+++ b/example.env.production
@@ -45,6 +45,7 @@ SMTP_PASSWORD=pass
 # SMTP_HELO_DOMAIN=cottagelabs.com
 
 CONTACT_FORM_RECIPIENT_EMAIL=repo-admin@your-institution.ac.uk
+CONTACT_FORM_SENDER_EMAIL=repo-admin@your-institution.ac.uk
 CONTACT_FORM_SUBJECT_PREFIX="Willow Contact form:"
 NOTIFICATIONS_EMAIL_DEFAULT_FROM_ADDRESS=notifications@your-institution.ac.uk
 # USER_MANAGEMENT_EMAIL_FROM_ADDRESS is used for things like Forgotten Password.

--- a/willow/app/models/hyrax/contact_form.rb
+++ b/willow/app/models/hyrax/contact_form.rb
@@ -19,13 +19,14 @@ module Hyrax
           subject: "#{Hyrax.config.subject_prefix} #{subject}",
           to: Hyrax.config.contact_email,
 
+          # Default case:
           # Send email from the admin contact inbox to itself. E.g. if configured to repo-admin@example.ac.uk, email
           # will come from that address and also go to that address. Send on behalf of the actual user's email address
           # (the `email` variable) will only be successful if we have permission to send email on behalf of that user.
           # If the user enters a @gmail.com or @btinternet.com address, we have no chance of obtaining permission and
           # SMTP servers will reject the message, causing the form to fail to send anything.
           # The message body (see the contact_mailer view in Hyrax) still contains the user's email address for admins to see.
-          from: Hyrax.config.contact_email  # use `email` as the value instead to try to send on behalf of the user
+          from: ENV['CONTACT_FORM_SENDER_EMAIL'] || Hyrax.config.contact_email  # use `email` as the value instead to try to send on behalf of the user
       }
     end
     


### PR DESCRIPTION
Allows the form to work with a `noreply@` address. Previously that address would be used for both TO and FROM, and a noreply can't send to itself since it cannot receive mail.