### PR TITLE
Bugfix/move create message to approve

### DIFF
--- a/willow/app/controllers/concerns/hyrax/notifications/notifiers.rb
+++ b/willow/app/controllers/concerns/hyrax/notifications/notifiers.rb
@@ -4,10 +4,7 @@ module Hyrax
       extend ActiveSupport::Concern
       included do
 
-        def after_create_response
-          ActiveSupport::Notifications.instrument("MetadataCreate", {curation_concern_type: self.class.curation_concern_type, object: curation_concern})
-          super
-        end
+        # no after_create_response here as the "create" event should be handled only after the item has been approved
 
         def after_update_response
           ActiveSupport::Notifications.instrument("MetadataUpdate", {curation_concern_type: self.class.curation_concern_type, object: curation_concern})

--- a/willow/config/workflows/mediated_deposit_workflow.json
+++ b/willow/config/workflows/mediated_deposit_workflow.json
@@ -49,7 +49,8 @@
                     "methods": [
                         "Hyrax::Workflow::GrantReadToDepositor",
                         "Hyrax::Workflow::RevokeEditFromDepositor",
-                        "Hyrax::Workflow::ActivateObject"
+                        "Hyrax::Workflow::ActivateObject",
+                        "Hyrax::Notifications::Senders::Approve"
                     ]
                 }, {
                     "name": "request_review",

--- a/willow/lib/hyrax/notifications/senders/approve.rb
+++ b/willow/lib/hyrax/notifications/senders/approve.rb
@@ -1,0 +1,17 @@
+module Hyrax
+  module Notifications
+    module Senders
+      module Approve
+      extend ActiveSupport::Concern
+
+        def self.call(target:, **)
+          # When an item is approved, send the MetadataCreate message. Subsequent edits / deletes will be handled by
+          # the controllers
+          ActiveSupport::Notifications.instrument("MetadataCreate", {curation_concern_type: target.class, object: target})
+
+          true # important to return true here
+        end
+      end
+    end
+  end
+end

--- a/willow/spec/messages/controllers/articles_controller_spec.rb
+++ b/willow/spec/messages/controllers/articles_controller_spec.rb
@@ -76,9 +76,10 @@ describe Hyrax::ArticlesController, :type => :controller do
     before :each do
       allow(Hyrax::CurationConcern).to receive(:actor).and_return(actor)
       allow(controller).to receive(:curation_concern).and_return(article)
-
+      post :create, params: { article: { title: [''] } }
       @message = notification_message_for('MetadataCreate') do
-        post :create, params: { article: { title: [''] } }
+        # trigger the approve workflow message
+        Hyrax::Notifications::Senders::Approve.call(target: article)
       end
       @messageHeader=@message[:messageHeader]
       @messageBody=@message[:messageBody]

--- a/willow/spec/messages/controllers/books_controller_spec.rb
+++ b/willow/spec/messages/controllers/books_controller_spec.rb
@@ -50,9 +50,10 @@ describe Hyrax::BooksController, :type => :controller do
     before :each do
       allow(Hyrax::CurationConcern).to receive(:actor).and_return(actor)
       allow(controller).to receive(:curation_concern).and_return(work)
-
+      post :create, params: { work: { title: [''] } }
       @message = notification_message_for('MetadataCreate') do
-        post :create, params: { work: { title: [''] } }
+        # trigger the approve workflow message
+        Hyrax::Notifications::Senders::Approve.call(target: work)
       end
       @messageHeader=@message[:messageHeader]
       @messageBody=@message[:messageBody]

--- a/willow/spec/messages/controllers/datasets_controller_spec.rb
+++ b/willow/spec/messages/controllers/datasets_controller_spec.rb
@@ -76,9 +76,10 @@ describe Hyrax::DatasetsController, :type => :controller do
     before :each do
       allow(Hyrax::CurationConcern).to receive(:actor).and_return(actor)
       allow(controller).to receive(:curation_concern).and_return(dataset)
-
+      post :create, params: { dataset: { title: [''] } }
       @message = notification_message_for('MetadataCreate') do
-        post :create, params: { dataset: { title: [''] } }
+        # trigger the approve workflow message
+        Hyrax::Notifications::Senders::Approve.call(target: dataset)
       end
       @messageHeader=@message[:messageHeader]
       @messageBody=@message[:messageBody]

--- a/willow/spec/messages/controllers/images_controller_spec.rb
+++ b/willow/spec/messages/controllers/images_controller_spec.rb
@@ -50,9 +50,10 @@ describe Hyrax::ImagesController, :type => :controller do
     before :each do
       allow(Hyrax::CurationConcern).to receive(:actor).and_return(actor)
       allow(controller).to receive(:curation_concern).and_return(work)
-
+      post :create, params: { work: { title: [''] } }
       @message = notification_message_for('MetadataCreate') do
-        post :create, params: { work: { title: [''] } }
+        # trigger the approve workflow message
+        Hyrax::Notifications::Senders::Approve.call(target: work)
       end
       @messageHeader=@message[:messageHeader]
       @messageBody=@message[:messageBody]


### PR DESCRIPTION
This is a bugfix for issue RDSSWIL-33 and resolves it by moving the create message to the approval stage. Delete and Update messages are unaffected.