### PR TITLE
Fix/file urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,9 @@ USER_MANAGEMENT_EMAIL_FROM_ADDRESS=no-reply@your-institution.ac.uk
 EMAIL_BASE_URL_HOST=repository.your-institution.ac.uk
 EMAIL_BASE_URL_SCHEMA=https
 
+# Optional custom host URL generation setting - if not present it will use EMAIL_BASE_URL_HOST above
+DEFAULT_URL_OPTIONS_HOST=repository.your-institution.ac.uk
+
 # Batch works editing
 BATCH_USER=repo_batch_user@your-institution.ac.uk
 AUDIT_USER=repo_audit_user@your-institution.ac.uk

--- a/README.md
+++ b/README.md
@@ -113,12 +113,10 @@ NOTIFICATIONS_EMAIL_DEFAULT_FROM_ADDRESS=notifications@your-institution.ac.uk
 # USER_MANAGEMENT_EMAIL_FROM_ADDRESS is used for things like Forgotten Password.
 # Make sure it's an email + domain you are allowed to send on behalf of, or your user management emails won't work!
 USER_MANAGEMENT_EMAIL_FROM_ADDRESS=no-reply@your-institution.ac.uk
-# Where should links in emails go to? The following options configure the stem / base URL for those links:
-EMAIL_BASE_URL_HOST=repository.your-institution.ac.uk
-EMAIL_BASE_URL_SCHEMA=https
 
-# Optional custom host URL generation setting - if not present it will use EMAIL_BASE_URL_HOST above
+# Configuration of URL generation for Emails and API Messages
 DEFAULT_URL_OPTIONS_HOST=repository.your-institution.ac.uk
+DEFAULT_URL_OPTIONS_PROTOCOL=http
 
 # Batch works editing
 BATCH_USER=repo_batch_user@your-institution.ac.uk

--- a/example.env.production
+++ b/example.env.production
@@ -55,6 +55,9 @@ USER_MANAGEMENT_EMAIL_FROM_ADDRESS=no-reply@your-institution.ac.uk
 EMAIL_BASE_URL_HOST=repository.your-institution.ac.uk
 EMAIL_BASE_URL_SCHEMA=https
 
+# Optional custom host URL generation setting - if not present it will use EMAIL_BASE_URL_HOST above
+DEFAULT_URL_OPTIONS_HOST=repository.your-institution.ac.uk
+
 # Batch works editing
 BATCH_USER=repo_batch_user@your-institution.ac.uk
 AUDIT_USER=repo_audit_user@your-institution.ac.uk

--- a/example.env.production
+++ b/example.env.production
@@ -51,12 +51,10 @@ NOTIFICATIONS_EMAIL_DEFAULT_FROM_ADDRESS=notifications@your-institution.ac.uk
 # USER_MANAGEMENT_EMAIL_FROM_ADDRESS is used for things like Forgotten Password.
 # Make sure it's an email + domain you are allowed to send on behalf of, or your user management emails won't work!
 USER_MANAGEMENT_EMAIL_FROM_ADDRESS=no-reply@your-institution.ac.uk
-# Where should links in emails go to? The following options configure the stem / base URL for those links:
-EMAIL_BASE_URL_HOST=repository.your-institution.ac.uk
-EMAIL_BASE_URL_SCHEMA=https
 
-# Optional custom host URL generation setting - if not present it will use EMAIL_BASE_URL_HOST above
+# Configuration of URL generation for Emails and API Messages
 DEFAULT_URL_OPTIONS_HOST=repository.your-institution.ac.uk
+DEFAULT_URL_OPTIONS_PROTOCOL=http
 
 # Batch works editing
 BATCH_USER=repo_batch_user@your-institution.ac.uk

--- a/willow/app/controllers/concerns/hyrax/notifications/notifiers.rb
+++ b/willow/app/controllers/concerns/hyrax/notifications/notifiers.rb
@@ -5,14 +5,21 @@ module Hyrax
       included do
 
         # no after_create_response here as the "create" event should be handled only after the item has been approved
+        # def after_create_response
+        #   ActiveSupport::Notifications.instrument(Events::METADATA_CREATE, {curation_concern_type: self.class.curation_concern_type, object: curation_concern})
+        #   super
+        # end
 
         def after_update_response
-          ActiveSupport::Notifications.instrument("MetadataUpdate", {curation_concern_type: self.class.curation_concern_type, object: curation_concern})
+          # only send METADATA_UPDATE message if the object is active
+          if curation_concern.state.id == 'http://fedora.info/definitions/1/0/access/ObjState#active'
+            ActiveSupport::Notifications.instrument(Events::METADATA_UPDATE, {curation_concern_type: self.class.curation_concern_type, object: curation_concern})
+          end
           super
         end
 
         def after_destroy_response(title)
-          ActiveSupport::Notifications.instrument("MetadataDelete", {curation_concern_type: self.class.curation_concern_type, object: curation_concern})
+          ActiveSupport::Notifications.instrument(Events::METADATA_DELETE, {curation_concern_type: self.class.curation_concern_type, object: curation_concern})
           super
         end
 

--- a/willow/config/initializers/action_mailer.rb
+++ b/willow/config/initializers/action_mailer.rb
@@ -17,8 +17,8 @@ Rails.application.configure do
   config.action_mailer.smtp_settings = smtp_settings
 
   config.action_mailer.default_url_options = {
-      host: ENV['EMAIL_BASE_URL_HOST'] || 'localhost',
-      protocol: ENV['EMAIL_BASE_URL_SCHEMA'] || 'http',
+      host: ENV['DEFAULT_URL_OPTIONS_HOST'] || 'localhost',
+      protocol: ENV['DEFAULT_URL_OPTIONS_PROTOCOL'] || 'http',
   }
-  config.action_mailer.asset_host = "#{ENV['EMAIL_BASE_URL_SCHEMA'] || 'http'}://#{ENV['EMAIL_BASE_URL_HOST'] || 'localhost'}"
+  config.action_mailer.asset_host = "#{ENV['DEFAULT_URL_OPTIONS_PROTOCOL'] || 'http'}://#{ENV['DEFAULT_URL_OPTIONS_HOST'] || 'localhost'}"
 end

--- a/willow/config/routes.rb
+++ b/willow/config/routes.rb
@@ -33,5 +33,7 @@ Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 end
 
-# Used to generate URLs in libraries that do not have full access to the Rails stack. Will default to the email host name if not provided.
-Rails.application.routes.default_url_options[:host] = ENV['DEFAULT_URL_OPTIONS_HOST'] || ENV['EMAIL_BASE_URL_HOST'] || 'localhost'
+# Used to generate URLs in libraries that do not have access to the Rails request pipeline. The same settings
+# are used for email generation.
+Rails.application.routes.default_url_options[:host] = ENV['DEFAULT_URL_OPTIONS_HOST'] || 'localhost'
+Rails.application.routes.default_url_options[:protocol] = ENV['DEFAULT_URL_OPTIONS_PROTOCOL'] || 'http'

--- a/willow/config/routes.rb
+++ b/willow/config/routes.rb
@@ -32,3 +32,6 @@ Rails.application.routes.draw do
 
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 end
+
+# Used to generate URLs in libraries that do not have full access to the Rails stack. Will default to the email host name if not provided.
+Rails.application.routes.default_url_options[:host] = ENV['DEFAULT_URL_OPTIONS_HOST'] || ENV['EMAIL_BASE_URL_HOST'] || 'localhost'

--- a/willow/lib/hyrax/notifications/events.rb
+++ b/willow/lib/hyrax/notifications/events.rb
@@ -1,0 +1,9 @@
+module Hyrax
+  module Notifications
+    class Events
+      METADATA_CREATE='MetadataCreate'.freeze
+      METADATA_UPDATE='MetadataUpdate'.freeze
+      METADATA_DELETE='MetadataDelete'.freeze
+    end
+  end
+end

--- a/willow/lib/hyrax/notifications/senders/approve.rb
+++ b/willow/lib/hyrax/notifications/senders/approve.rb
@@ -5,9 +5,16 @@ module Hyrax
       extend ActiveSupport::Concern
 
         def self.call(target:, **)
-          # When an item is approved, send the MetadataCreate message. Subsequent edits / deletes will be handled by
-          # the controllers
-          ActiveSupport::Notifications.instrument("MetadataCreate", {curation_concern_type: target.class, object: target})
+          # When an item is approved, send the appropriate metadata message depending on whether it has been previously
+          # deposited.
+          if target.import_url.present?
+            ActiveSupport::Notifications.instrument(Events::METADATA_UPDATE, {curation_concern_type: target.class, object: target})
+          else
+            ActiveSupport::Notifications.instrument(Events::METADATA_CREATE, {curation_concern_type: target.class, object: target})
+            target.update(import_url: 'true')
+            # This is a bit of a bodge - but can't store this in Redis (not long-term persistent) and we shouldn't store
+            # it in Fedora (as it is internal admin data, not strictly related to object). So in the database for now.
+          end
 
           true # important to return true here
         end

--- a/willow/lib/hyrax/notifications/subscribers/build_message.rb
+++ b/willow/lib/hyrax/notifications/subscribers/build_message.rb
@@ -271,6 +271,28 @@ module Hyrax
                   fileIdentifier: download_url(fs, host: Rails.application.routes.default_url_options[:host]),
                   fileName: fs.first_title,
                   fileSize: fs.file_size.first,
+                  fileChecksum: fs.original_checksum.map{|c| {
+                      checksumType: UNKNOWN_ID,
+                      checksumValue: c
+                  }},
+                  fileCompositionLevel: UNKNOWN,
+                  fileDateModified: [
+                      {
+                          dateValue: UNKNOWN,
+                          dateType: UNKNOWN_ID
+                      }
+                  ],
+                  fileUse: UNKNOWN_ID,
+                  filePreservationEvent: [
+                    {
+                        preservationEventValue: UNKNOWN,
+                        preservationEventType: UNKNOWN_ID,
+                        preservationEventDetail: UNKNOWN
+                    }  
+                  ],
+                  fileUploadStatus: UNKNOWN_ID,
+                  fileStorageStatus: UNKNOWN_ID,
+                  fileStorageLocation: UNKNOWN,
                   fileStorageType: UNKNOWN_ID
               }
             end

--- a/willow/lib/hyrax/notifications/subscribers/build_message.rb
+++ b/willow/lib/hyrax/notifications/subscribers/build_message.rb
@@ -288,7 +288,7 @@ module Hyrax
                         preservationEventValue: UNKNOWN,
                         preservationEventType: UNKNOWN_ID,
                         preservationEventDetail: UNKNOWN
-                    }  
+                    }
                   ],
                   fileUploadStatus: UNKNOWN_ID,
                   fileStorageStatus: UNKNOWN_ID,

--- a/willow/lib/hyrax/notifications/subscribers/kinesis.rb
+++ b/willow/lib/hyrax/notifications/subscribers/kinesis.rb
@@ -5,7 +5,7 @@ module Hyrax
     module Subscribers
       class Kinesis < Subscriber
 
-        def self.register_aws(events: ['MetadataCreate', 'MetadataUpdate', 'MetadataDelete'],
+        def self.register_aws(events: [Events::METADATA_CREATE, Events::METADATA_UPDATE, Events::METADATA_DELETE],
             region: 'eu-west-1',
             stream_name: 'willow-message-stream', shard_count: 1, partition_key: 'willow')
 
@@ -23,7 +23,7 @@ module Hyrax
           @subscriber = self.new(region, stream_name, shard_count, partition_key).subscribe(events)
         end
 
-        def self.register_kinesalite(events: ['MetadataCreate', 'MetadataUpdate', 'MetadataDelete'],
+        def self.register_kinesalite(events: [Events::METADATA_CREATE, Events::METADATA_UPDATE, Events::METADATA_DELETE],
             endpoint: nil, region: 'nowhere',
             stream_name: 'willow-message-stream', shard_count: 1, partition_key: 'willow')
 

--- a/willow/lib/hyrax/notifications/subscribers/subscriber.rb
+++ b/willow/lib/hyrax/notifications/subscribers/subscriber.rb
@@ -3,7 +3,7 @@ module Hyrax
     module Subscribers
       class Subscriber
 
-        def self.register(events: ['MetadataCreate', 'MetadataUpdate', 'MetadataDelete'])
+        def self.register(events: [Events::METADATA_CREATE, Events::METADATA_UPDATE, Events::METADATA_DELETE])
           @subscriber = self.new().subscribe(events)
         end
 

--- a/willow/spec/messages/controllers/articles_controller_spec.rb
+++ b/willow/spec/messages/controllers/articles_controller_spec.rb
@@ -77,7 +77,7 @@ describe Hyrax::ArticlesController, :type => :controller do
       allow(Hyrax::CurationConcern).to receive(:actor).and_return(actor)
       allow(controller).to receive(:curation_concern).and_return(article)
       post :create, params: { article: { title: [''] } }
-      @message = notification_message_for('MetadataCreate') do
+      @message = notification_message_for(Hyrax::Notifications::Events::METADATA_CREATE) do
         # trigger the approve workflow message
         Hyrax::Notifications::Senders::Approve.call(target: article)
       end

--- a/willow/spec/messages/controllers/articles_controller_spec.rb
+++ b/willow/spec/messages/controllers/articles_controller_spec.rb
@@ -57,7 +57,8 @@ describe Hyrax::ArticlesController, :type => :controller do
                                                          classification: 'PSC',
                                                          homepage: 'http://example.com/homepage'
                                                      }],
-                         language: ["English"]
+                         language: ["English"],
+                         import_url: 'true'
   ) }
 
 
@@ -77,7 +78,7 @@ describe Hyrax::ArticlesController, :type => :controller do
       allow(Hyrax::CurationConcern).to receive(:actor).and_return(actor)
       allow(controller).to receive(:curation_concern).and_return(article)
       post :create, params: { article: { title: [''] } }
-      @message = notification_message_for(Hyrax::Notifications::Events::METADATA_CREATE) do
+      @message = notification_message_for(Hyrax::Notifications::Events::METADATA_UPDATE) do
         # trigger the approve workflow message
         Hyrax::Notifications::Senders::Approve.call(target: article)
       end
@@ -96,11 +97,11 @@ describe Hyrax::ArticlesController, :type => :controller do
     end
 
     it 'messageType is create' do
-      expect(@messageHeader[:messageType]).to eql('MetadataCreate')
+      expect(@messageHeader[:messageType]).to eql('MetadataUpdate')
     end
 
     it 'payload contains objectTitle' do
-      expect(@messageBodyPayload[:objectTitle]).to eql(article.title.first)
+      expect(@messageBodyPayload[:objectTitle]).to eql('Do Mug Fairies Exist? An experiment in self-cleaning crockery')
     end
   end
 end

--- a/willow/spec/messages/controllers/books_controller_spec.rb
+++ b/willow/spec/messages/controllers/books_controller_spec.rb
@@ -31,7 +31,8 @@ describe Hyrax::BooksController, :type => :controller do
                       publisher: ["Society of Psychoceramics"],
                       date_created: ['2014-04-01'],
                       subject: ["Psychoceramics"],
-                      language: ["English"]
+                      language: ["English"],
+                      import_url: 'true'
   ) }
 
 
@@ -50,8 +51,11 @@ describe Hyrax::BooksController, :type => :controller do
     before :each do
       allow(Hyrax::CurationConcern).to receive(:actor).and_return(actor)
       allow(controller).to receive(:curation_concern).and_return(work)
+      allow_any_instance_of(Hyrax::Notifications::Subscribers::BuildMessage).to receive(:download_url).and_return('http://some.url.com/download/1')
+      allow_any_instance_of(FileSet).to receive(:file_size).and_return([12345])
+      allow_any_instance_of(FileSet).to receive(:original_checksum).and_return(['12345'])
       post :create, params: { work: { title: [''] } }
-      @message = notification_message_for(Hyrax::Notifications::Events::METADATA_CREATE) do
+      @message = notification_message_for(Hyrax::Notifications::Events::METADATA_UPDATE) do
         # trigger the approve workflow message
         Hyrax::Notifications::Senders::Approve.call(target: work)
       end
@@ -70,11 +74,11 @@ describe Hyrax::BooksController, :type => :controller do
     end
 
     it 'messageType is create' do
-      expect(@messageHeader[:messageType]).to eql('MetadataCreate')
+      expect(@messageHeader[:messageType]).to eql('MetadataUpdate')
     end
 
     it 'payload contains objectTitle' do
-      expect(@messageBodyPayload[:objectTitle]).to eql(work.title.first)
+      expect(@messageBodyPayload[:objectTitle]).to eql('Do Mug Fairies Exist? An experiment in self-cleaning crockery')
     end
   end
 end

--- a/willow/spec/messages/controllers/books_controller_spec.rb
+++ b/willow/spec/messages/controllers/books_controller_spec.rb
@@ -51,7 +51,7 @@ describe Hyrax::BooksController, :type => :controller do
       allow(Hyrax::CurationConcern).to receive(:actor).and_return(actor)
       allow(controller).to receive(:curation_concern).and_return(work)
       post :create, params: { work: { title: [''] } }
-      @message = notification_message_for('MetadataCreate') do
+      @message = notification_message_for(Hyrax::Notifications::Events::METADATA_CREATE) do
         # trigger the approve workflow message
         Hyrax::Notifications::Senders::Approve.call(target: work)
       end

--- a/willow/spec/messages/controllers/datasets_controller_spec.rb
+++ b/willow/spec/messages/controllers/datasets_controller_spec.rb
@@ -57,7 +57,8 @@ describe Hyrax::DatasetsController, :type => :controller do
                                                          classification: 'PSC',
                                                          homepage: 'http://example.com/homepage'
                                                      }],
-                         language: ["English"]
+                         language: ["English"],
+                         import_url: 'true'
   ) }
 
 
@@ -77,7 +78,7 @@ describe Hyrax::DatasetsController, :type => :controller do
       allow(Hyrax::CurationConcern).to receive(:actor).and_return(actor)
       allow(controller).to receive(:curation_concern).and_return(dataset)
       post :create, params: { dataset: { title: [''] } }
-      @message = notification_message_for(Hyrax::Notifications::Events::METADATA_CREATE) do
+      @message = notification_message_for(Hyrax::Notifications::Events::METADATA_UPDATE) do
         # trigger the approve workflow message
         Hyrax::Notifications::Senders::Approve.call(target: dataset)
       end
@@ -96,11 +97,11 @@ describe Hyrax::DatasetsController, :type => :controller do
     end
 
     it 'messageType is create' do
-      expect(@messageHeader[:messageType]).to eql('MetadataCreate')
+      expect(@messageHeader[:messageType]).to eql('MetadataUpdate')
     end
 
     it 'payload contains objectTitle' do
-      expect(@messageBodyPayload[:objectTitle]).to eql(dataset.title.first)
+      expect(@messageBodyPayload[:objectTitle]).to eql('Do Mug Fairies Exist? An experiment in self-cleaning crockery')
     end
   end
 end

--- a/willow/spec/messages/controllers/datasets_controller_spec.rb
+++ b/willow/spec/messages/controllers/datasets_controller_spec.rb
@@ -77,7 +77,7 @@ describe Hyrax::DatasetsController, :type => :controller do
       allow(Hyrax::CurationConcern).to receive(:actor).and_return(actor)
       allow(controller).to receive(:curation_concern).and_return(dataset)
       post :create, params: { dataset: { title: [''] } }
-      @message = notification_message_for('MetadataCreate') do
+      @message = notification_message_for(Hyrax::Notifications::Events::METADATA_CREATE) do
         # trigger the approve workflow message
         Hyrax::Notifications::Senders::Approve.call(target: dataset)
       end

--- a/willow/spec/messages/controllers/images_controller_spec.rb
+++ b/willow/spec/messages/controllers/images_controller_spec.rb
@@ -51,7 +51,7 @@ describe Hyrax::ImagesController, :type => :controller do
       allow(Hyrax::CurationConcern).to receive(:actor).and_return(actor)
       allow(controller).to receive(:curation_concern).and_return(work)
       post :create, params: { work: { title: [''] } }
-      @message = notification_message_for('MetadataCreate') do
+      @message = notification_message_for(Hyrax::Notifications::Events::METADATA_CREATE) do
         # trigger the approve workflow message
         Hyrax::Notifications::Senders::Approve.call(target: work)
       end

--- a/willow/spec/support/vcr.rb
+++ b/willow/spec/support/vcr.rb
@@ -10,7 +10,6 @@ VCR.configure do |config|
   # your HTTP request service.
   config.hook_into :webmock
   config.default_cassette_options = { match_requests_on: [:method, :uri],
-                                      re_record_interval: 6.weeks, # re-record tests to keep them up to date
                                       record: ENV["VCR_RECORD_MODE"] ? ENV["VCR_RECORD_MODE"].to_sym : :once }
   config.configure_rspec_metadata!
 end


### PR DESCRIPTION
Further fixes for issue RDSSWIL-33

* ensures URLs are to willow, not fedora
* ensures create message is sent only once, further calls are updates