### PR TITLE
Bugfix/logo display

### DIFF
--- a/willow/app/assets/stylesheets/willow.scss
+++ b/willow/app/assets/stylesheets/willow.scss
@@ -29,8 +29,8 @@ body.dashboard {
 footer.navbar.navbar-inverse {
   font-size: 18px;
   color: #aaa;
-  margin-top: 50px;
-  min-height: 220px;
+  margin-top: 20px;
+  min-height: 170px;
 }
 
 footer.navbar.navbar-inverse a {
@@ -52,8 +52,7 @@ footer.navbar.navbar-inverse a:hover {
 
 #masthead {
   min-height: 50px;
-  padding-top: 20px;
-  padding-bottom: 10px;
+  padding-top: 10px;
 }
 
 ul.nav.navbar-nav.col-sm-5.col-md-6 {
@@ -186,13 +185,22 @@ form .field-wrapper label[required="required"]::after {
 
 #logo_pic {
   padding: 0;
+  float:left;
+  height: 100%;
+  width: 50%;
 }
 
 #logo_pic img {
   object-fit: contain;
   height: 100%;
+  margin-top: -20px;
 }
 
 #logo {
   padding-left: 20px;
+}
+
+#navbar-col-2 {
+  widht: 50%;
+  float: right;
 }

--- a/willow/app/assets/stylesheets/willow.scss
+++ b/willow/app/assets/stylesheets/willow.scss
@@ -188,7 +188,7 @@ form .field-wrapper label[required="required"]::after {
   float:left;
   height: 100%;
   width: 50%;
-}
+
 
 #logo_pic img {
   object-fit: contain;
@@ -201,6 +201,6 @@ form .field-wrapper label[required="required"]::after {
 }
 
 #navbar-col-2 {
-  widht: 50%;
+  width: 50%;
   float: right;
 }

--- a/willow/app/assets/stylesheets/willow.scss
+++ b/willow/app/assets/stylesheets/willow.scss
@@ -185,10 +185,10 @@ form .field-wrapper label[required="required"]::after {
 
 #logo_pic {
   padding: 0;
-  float:left;
+  float: left;
   height: 100%;
   width: 50%;
-
+}
 
 #logo_pic img {
   object-fit: contain;

--- a/willow/app/views/_logo.html.erb
+++ b/willow/app/views/_logo.html.erb
@@ -1,3 +1,12 @@
-<a id="logo" class="navbar-brand" href="<%= hyrax.root_path %>" data-no-turbolink="true">
-  <span class="institution_name"><%= application_name.upcase %></span>
-</a>
+<div id="logo_pic">
+  <%- unless Willow::Config.institution_logo.blank? %>
+    <a class="pull-left" href="<%= hyrax.root_path %>" data-no-turbolink="true">
+      <img src=<%=Willow::Config.institution_logo%> />
+    </a>
+  <% else %>
+    <span class="institution_name hidden-xs hidden-sm"><a id="logo" class="navbar-brand"
+       href="<%= hyrax.root_path %>" data-no-turbolink="true">
+      <%= application_name.upcase %>
+    </a></span>
+  <% end %>
+</div>

--- a/willow/app/views/_logo_pic.html.erb
+++ b/willow/app/views/_logo_pic.html.erb
@@ -1,3 +1,0 @@
-<a id="logo_pic" class="navbar-brand" href="<%= hyrax.root_path %>" data-no-turbolink="true">
-  <img src=<%=Willow::Config.institution_logo%> />
-</a>

--- a/willow/app/views/_masthead.html.erb
+++ b/willow/app/views/_masthead.html.erb
@@ -1,27 +1,26 @@
 <%= render '/shared/select_work_type_modal' if create_work_presenter.many? %>
 <nav id="masthead" class="navbar navbar-inverse navbar-static-top" role="navigation">
-  <%- if Willow::Config.institution_logo %>
-    <%= render partial: '/logo_pic' %>
-  <% end %>
-  <div class="container-fluid">
-    <!-- Brand and toggle get grouped for better mobile display -->
-    <div class="navbar-header">
-      <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#top-navbar-collapse" aria-expanded="false">
-        <span class="sr-only">Toggle navigation</span>
-        <span class="icon-bar"></span>
-        <span class="icon-bar"></span>
-        <span class="icon-bar"></span>
-      </button>
-      <%= render partial: '/logo' %>
+  <%= render partial: '/logo' %>
+  <div id="navbar-col-2">
+    <div class="container-fluid">
+      <!-- Brand and toggle get grouped for better mobile display -->
+      <div class="navbar-header">
+        <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#top-navbar-collapse" aria-expanded="false">
+          <span class="sr-only">Toggle navigation</span>
+          <span class="icon-bar"></span>
+          <span class="icon-bar"></span>
+          <span class="icon-bar"></span>
+        </button>
+      </div>
+
+      <div class="pull-right hidden-xs hidden-sm" id="cl-name">
+        <%= Hyrax::Institution.name %>
+      </div>
+
     </div>
 
-    <div class="pull-right" style="display: inline-block !important" id="cl-name">
-      <%= Hyrax::Institution.name %>
+    <div class="collapse navbar-collapse" id="top-navbar-collapse">
+      <%= render partial: '/user_util_links' %>
     </div>
-
-  </div>
-
-  <div class="collapse navbar-collapse" id="top-navbar-collapse">
-    <%= render partial: '/user_util_links' %>
   </div>
 </nav>

--- a/willow/app/views/shared/_footer.html.erb
+++ b/willow/app/views/shared/_footer.html.erb
@@ -1,11 +1,11 @@
 <footer class="navbar navbar-inverse site-footer" id="footer">
   <div class="container-fluid">
     <div class="navbar-text text-left">
-      <p>email: <a href="mailto:willow@cottagelabs.com">willow@cottagelabs.com</a></p>
-      <p>twitter: <a href="http://twitter.com/cottagelabs">@cottagelabs</a></p>
-      <p>Site template - © Cottage Labs LLP 2011 - 2017, <a href="https://creativecommons.org/licenses/by/3.0/">CC-BY</a></p>
-      <p>Hyrax v<%= Hyrax::VERSION %>. <%= t('hyrax.footer.service_html') %></p>
-      <p><%= t('hyrax.footer.copyright_html') %></p>
+      <div>email: <a href="mailto:willow@cottagelabs.com">willow@cottagelabs.com</a></div>
+      <div>twitter: <a href="http://twitter.com/cottagelabs">@cottagelabs</a></div>
+      <div>Site template - © Cottage Labs LLP 2011 - 2017, <a href="https://creativecommons.org/licenses/by/3.0/">CC-BY</a></div>
+      <div>Hyrax v<%= Hyrax::VERSION %>. <%= t('hyrax.footer.service_html') %></div>
+      <div><%= t('hyrax.footer.copyright_html') %></div>
     </div>
   </div>
 </footer>


### PR DESCRIPTION
We got the logo for RCM. I modified the display so the logo is not restricted to 50px width and can use the entire header width if needed.

I also made it such that if there is a logo, the name Willow will not be displayed (RCM want the name removed). 

To test with rcm logo
 * download it from [http://rdss-institutional-ecs-clusters-objects-public.s3.amazonaws.com/747/rcm-horizontal-logo.png](http://rdss-institutional-ecs-clusters-objects-public.s3.amazonaws.com/747/rcm-horizontal-logo.png), 
 * move it to the willow/app/assets/images folder
 * add this line to .env.development 
```INSTITUTION_LOGO=http://localhost/assets/rcm-horizontal-logo.png```
 